### PR TITLE
Always use ingots prefix. Set aliases to preserve compatibility.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -27,8 +27,9 @@ function ingots.register_ingots(ingot_item, texture, is_big)
 	end
 
 	-- de hardcoded modname, which allows the api to be properly used from within other mods (thanks 'argyle')
-	local mod_name = minetest.get_current_modname()
-	local mod_prefix = mod_name .. ":"
+	local mod_current = minetest.get_current_modname()
+	local mod_target = ingot_item:split(":")[1]
+	local mod_prefix = "ingots:"
 
 	local stack_size = 64
 	local texture_prefix = "ingot_"
@@ -44,6 +45,10 @@ function ingots.register_ingots(ingot_item, texture, is_big)
 
 	--this way there is no need for a separate on_punch function for a stack of 1 ingot
 	minetest.register_alias(mod_prefix .. ingot_name .."_0", "air")
+	if mod_current ~= "ingots" then
+		minetest.register_alias(mod_current .. ":" .. ingot_name .."_0", "air")
+	end
+	minetest.register_alias(mod_target  .. ":" .. ingot_name .."_0", "air")
 
 	--gives the ingot_item the ability to be placed and increas already placed stacks of ingots
 	minetest.override_item(ingot_item, {
@@ -98,7 +103,7 @@ function ingots.register_ingots(ingot_item, texture, is_big)
 						ingots.get_box(is_big, i),
 					},
 				}
-		minetest.register_node(mod_prefix .. ingot_name .. "_" .. i,{
+		minetest.register_node(":" .. mod_prefix .. ingot_name .. "_" .. i,{
 			description = "ingots",
 			drawtype = "mesh",
 			tiles = {texture},
@@ -129,6 +134,10 @@ function ingots.register_ingots(ingot_item, texture, is_big)
 			_ingot_name = ingot_name,
 			_ingot_count = i,
 		})
+		if mod_current ~= "ingots" then
+			minetest.register_alias(mod_current .. ":" .. ingot_name .. "_" .. i, mod_prefix .. ingot_name .. "_" .. i )
+		end
+		minetest.register_alias(mod_target  .. ":" .. ingot_name .. "_" .. i, mod_prefix .. ingot_name .. "_" .. i )
 	end
 end
 


### PR DESCRIPTION
I recently ran into unknown block using ingots mod

I use factory mod, but registered ingots from a dummy local mod called mods_glue. Generated ingots were so named mods_glue:mithril_{1,64}. As factory seems unmaintained I moved ingots registration to local fork of factory mod -> mods_glue:mithril_{1,64} turned into unknown blocks.
Moreover, in case moreores and/or technic are not available factory mod registers mithril and silver ores.

So I decided to review the ingots mod and preserve compatibility:
   - all registered nodes follow: ":ingots:" .. "material_name_" .. "n"
   - use aliases for current_modname to preserve compatibility
   - use aliases for target_modname  (like factory registering moreores and/or technic ores)
The initial case is not covered by this fix and will never cover it, but in case somebody uses ingots he may register ingots from any helper mod, and the initial problem will not appear.